### PR TITLE
Added: fusermount should be used in Linux and umount with OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ On Debian like system you can simply add them via
 
     apt-get install couchdb fuse
 
+On OSX:
+* `brew install couchdb` (Homebrew) or `sudo port install couchdb && sudo port update couchdb && sudo port load couchdb` (MacPorts)
+* Download and install [OSXFuse](http://osxfuse.github.io/)
+
 ## Installation
 
 In a console run:
@@ -32,6 +36,8 @@ Configure your replication:
 On Ubuntu you must add read rights on `/etc/fuse.conf`
 
     chmod a+r /etc/fuse.conf
+
+On OSX, you must start CouchDB manually in a terminal, simply type `couchdb`
 
 
 ## Troubleshootings

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ On OSX:
 
 In a console run:
 
-   pip install git+git@github.com:mycozycloud/cozy-fuse-linux.git
+    pip install git+git@github.com:mycozycloud/cozy-fuse-linux.git
 
 
 Configure your replication:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Configure your replication:
 
     # Configure once your cozy
     cozy-fuse new_cozy -u https://mycozy.cozycloud.cc -n online-cozy -p /home/me/mycozyfolder
-    cozy-fuse sync -n online -cozy # run it at each startup
-    cozy-fuse mount -n online -cozy # run it at each startup
+    cozy-fuse sync -n online-cozy # run it at each startup
+    cozy-fuse mount -n online-cozy # run it at each startup
 
 On Ubuntu you must add read rights on `/etc/fuse.conf`
 

--- a/cozyfuse/couchmount.py
+++ b/cozyfuse/couchmount.py
@@ -9,6 +9,7 @@
 # you should have received as part of this distribution.
 
 import os
+import platform
 import errno
 import fuse
 import stat
@@ -493,9 +494,17 @@ def _recover_path():
 
 
 def unmount(path):
+
     if path is None:
         path = _recover_path()
-    subprocess.call(["fusermount", "-u", path])
+
+    if platform.system() == "Darwin":
+        command = ["umount", path]
+    else:
+        command = ["fusermount", "-u", path]
+
+    subprocess.call(command)
+    print 'Folder %s unmounted' % path
 
 
 def mount(name, path):


### PR DESCRIPTION
In order to push the OSX compatibility, I had to use a different command to unmount a folder.
